### PR TITLE
Add CSV export and test

### DIFF
--- a/bin/content-style
+++ b/bin/content-style
@@ -8,7 +8,8 @@ config_path = File.read(File.join(Dir.pwd, 'config', 'content-style.yml'))
 config_file = YAML.load(config_path)
 config = config_file.fetch('ContentStyle')
 filetype = config.fetch('filetype')
-excluded_files = config.fetch('excluded_files') || []
+excluded_files = config.fetch('excluded_files', [])
+csv = config.fetch('csv', false)
 excluded_file_paths =
   excluded_files.map do |excluded_file|
     File.expand_path(excluded_file)
@@ -36,3 +37,16 @@ violations.each do |msg|
 end
 
 puts config.fetch('addendum', '') unless violations.empty?
+
+if csv
+  csv_path = command + '/content-style-output.csv'
+  output_csv = File.open(csv_path, 'w')
+  output_csv.puts ['File,Line,Violation']
+  violations.each do |msg|
+    csv_msg = msg.to_s.gsub(/\:|\: /, ',')
+                 .delete(command + '/')
+    output_csv.puts csv_msg
+  end
+  results_location = 'CSV of results is located at ' + csv_path
+  puts results_location
+end

--- a/spec/bin/bin_content_style_spec.rb
+++ b/spec/bin/bin_content_style_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Run command `content-style text/html`', type: :aruba do
+RSpec.describe 'Run command `content-style test/html`', type: :aruba do
   context 'when an html file containing a violation is located in `test/html` and config file is
           located at `config/content-style.yml`' do
     before(:each) do
@@ -12,9 +12,7 @@ RSpec.describe 'Run command `content-style text/html`', type: :aruba do
       expect(last_command_started.stdout.chomp).to include 'dropdown'
     end
   end
-end
 
-RSpec.describe 'Run command `content-style text/html`', type: :aruba do
   context 'when a file marked for exclusion contains a violation' do
     before(:each) do
       run_simple 'bin/content-style test/html'
@@ -22,6 +20,22 @@ RSpec.describe 'Run command `content-style text/html`', type: :aruba do
     it 'does not write error message for violation in excluded file' do
       expect(last_command_started.stdout.chomp).to include 'dropdown'
       expect(last_command_started.stdout.chomp).not_to include 'droop down'
+    end
+  end
+
+  context 'when csv output is enabled' do
+    let(:csv) do
+      'test/html/content-style-output.csv'
+    end
+    let(:dropdown) do
+      /dropdown/
+    end
+    before(:each) do
+      run_simple 'bin/content-style test/html'
+    end
+    it 'generates a CSV file with the correct error message' do
+      expect(csv).to be_an_existing_file
+      expect(csv).to have_file_content dropdown
     end
   end
 end

--- a/spec/support/hooks.rb
+++ b/spec/support/hooks.rb
@@ -13,6 +13,7 @@ ContentStyle:
   enabled: true
   addendum: 'Questions?'
   filetype: 'html'
+  csv: true
   exceptions:
     - 'manual change'
     - 'Amazon docs'
@@ -45,7 +46,6 @@ FILE
       You'll never hear from us.
     </p>
 FILE
-
     create_directory(config_directory)
     write_file(config_file, config_content)
     create_directory(html_directory)


### PR DESCRIPTION
This PR adds csv true/false to config, and imports that value into the binary. If that's enabled, content-style now generates a CSV of results.